### PR TITLE
为系统实现iozone测例

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "lazyinit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1304,7 @@ dependencies = [
 name = "starry-core"
 version = "0.1.0"
 dependencies = [
+ "axalloc",
  "axconfig",
  "axerrno",
  "axfs",
@@ -1308,6 +1318,7 @@ dependencies = [
  "axtask",
  "crate_interface",
  "kernel-elf-parser",
+ "lazy_static",
  "linkme",
  "memory_addr",
  "numeric-enum-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ axfeat = { git = "https://github.com/oscomp/arceos.git", features = [
 ] }
 
 axconfig = { git = "https://github.com/oscomp/arceos.git" }
+axalloc = { git = "https://github.com/oscomp/arceos.git" }
 axfs = { git = "https://github.com/oscomp/arceos.git" }
 axhal = { git = "https://github.com/oscomp/arceos.git", features = ["uspace"] }
 axlog = { git = "https://github.com/oscomp/arceos.git" }

--- a/api/src/file/fs.rs
+++ b/api/src/file/fs.rs
@@ -43,6 +43,14 @@ impl FileLike for File {
         Ok(self.inner().write(buf)?)
     }
 
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> LinuxResult<usize> {
+        Ok(self.inner().read_at(offset, buf)?)
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> LinuxResult<usize> {
+        Ok(self.inner().write_at(offset, buf)?)
+    }
+
     fn stat(&self) -> LinuxResult<Kstat> {
         let metadata = self.inner().get_attr()?;
         let ty = metadata.file_type() as u8;
@@ -55,6 +63,16 @@ impl FileLike for File {
             blksize: 512,
             ..Default::default()
         })
+    }
+
+    fn truncate(&self, len: u64) -> LinuxResult {
+        self.inner().truncate(len)?;
+        Ok(())
+    }
+
+    fn fsync(&self) -> LinuxResult {
+        self.inner().fsync()?;
+        Ok(())
     }
 
     fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {

--- a/api/src/file/mod.rs
+++ b/api/src/file/mod.rs
@@ -101,7 +101,24 @@ impl From<Kstat> for statx {
 pub trait FileLike: Send + Sync {
     fn read(&self, buf: &mut [u8]) -> LinuxResult<usize>;
     fn write(&self, buf: &[u8]) -> LinuxResult<usize>;
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> LinuxResult<usize> {
+        let _ = offset;
+        let _ = buf;
+        Err(LinuxError::ESPIPE)
+    }
+    fn write_at(&self, offset: u64, buf: &[u8]) -> LinuxResult<usize> {
+        let _ = offset;
+        let _ = buf;
+        Err(LinuxError::ESPIPE)
+    }
     fn stat(&self) -> LinuxResult<Kstat>;
+    fn truncate(&self, len: u64) -> LinuxResult {
+        let _ = len;
+        Err(LinuxError::EINVAL)
+    }
+    fn fsync(&self) -> LinuxResult {
+        Err(LinuxError::EINVAL)
+    }
     fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
     fn poll(&self) -> LinuxResult<PollState>;
     fn set_nonblocking(&self, nonblocking: bool) -> LinuxResult;
@@ -145,6 +162,17 @@ impl FD_TABLE {
         for id in ids {
             let _ = table.remove(id);
         }
+    }
+
+    /// Synchronize all open files in the file descriptor table.
+    pub fn sync_all(&self) -> LinuxResult {
+        let table = self.read();
+        for id in table.ids() {
+            if let Some(file) = table.get(id) {
+                file.fsync()?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/api/src/imp/fs/io.rs
+++ b/api/src/imp/fs/io.rs
@@ -5,9 +5,91 @@ use axio::SeekFrom;
 use linux_raw_sys::general::{__kernel_off_t, iovec};
 
 use crate::{
-    file::{File, FileLike, get_file_like},
+    file::{FD_TABLE, File, FileLike, get_file_like},
     ptr::{UserConstPtr, UserPtr},
 };
+
+/// Read data from the file indicated by `fd` at a specific offset.
+///
+/// This function reads up to `len` bytes from file descriptor `fd` at offset
+/// `offset` into the buffer pointed to by `buf`. The file offset is not changed.
+///
+/// Return the number of bytes read if success.
+pub fn sys_pread64(fd: c_int, buf: UserPtr<u8>, len: usize, offset: u64) -> LinuxResult<isize> {
+    let buf = buf.get_as_mut_slice(len)?;
+    debug!(
+        "sys_pread64 <= fd: {}, buf: {:p}, len: {}, offset: {}",
+        fd,
+        buf.as_ptr(),
+        buf.len(),
+        offset
+    );
+    Ok(get_file_like(fd)?.read_at(offset, buf)? as _)
+}
+
+/// Write data to the file indicated by `fd` at a specific offset.
+///
+/// This function writes up to `len` bytes from the buffer pointed to by `buf`
+/// to the file associated with the file descriptor `fd` at offset `offset`.
+/// The file offset is not changed.
+///
+/// Return the number of bytes written if success.
+pub fn sys_pwrite64(
+    fd: c_int,
+    buf: UserConstPtr<u8>,
+    len: usize,
+    offset: u64,
+) -> LinuxResult<isize> {
+    let buf = buf.get_as_slice(len)?;
+    debug!(
+        "sys_pwrite64 <= fd: {}, buf: {:p}, len: {}, offset: {}",
+        fd,
+        buf.as_ptr(),
+        buf.len(),
+        offset
+    );
+    Ok(get_file_like(fd)?.write_at(offset, buf)? as _)
+}
+
+/// Truncate a file to a specified length.
+///
+/// This function causes the regular file named by `fd` to be truncated to a size of
+/// precisely `len` bytes. If the file previously was larger than this size, the extra
+/// data is lost. If the file previously was shorter, it is extended, and the extended
+/// part reads as null bytes.
+///
+/// Return 0 on success.
+pub fn sys_ftruncate(fd: c_int, len: u64) -> LinuxResult<isize> {
+    debug!("sys_ftruncate <= fd: {}, len: {}", fd, len);
+    get_file_like(fd)?.truncate(len)?;
+    Ok(0)
+}
+
+/// Synchronize a file's in-core state with storage device.
+///
+/// This function transfers ("flushes") all modified in-core data of the file
+/// referred to by file descriptor `fd` to the disk device so that all changed
+/// information can be retrieved even after the system crashed or was rebooted.
+///
+/// Return 0 on success.
+pub fn sys_fsync(fd: c_int) -> LinuxResult<isize> {
+    debug!("sys_fsync <= fd: {}", fd);
+    get_file_like(fd)?.fsync()?;
+    Ok(0)
+}
+
+/// Synchronize all file systems.
+///
+/// This function causes all pending modifications to filesystem metadata and
+/// cached file data to be written to the underlying filesystems. It is equivalent
+/// to calling fsync() on every open file descriptor.
+///
+/// Return 0 on success.
+pub fn sys_sync() -> LinuxResult<isize> {
+    debug!("sys_sync");
+    FD_TABLE.sync_all()?;
+    Ok(0)
+}
 
 /// Read data from the file indicated by `fd`.
 ///
@@ -23,6 +105,13 @@ pub fn sys_read(fd: i32, buf: UserPtr<u8>, len: usize) -> LinuxResult<isize> {
     Ok(get_file_like(fd)?.read(buf)? as _)
 }
 
+/// Read data from the file using a vector of buffers.
+///
+/// This function performs the same task as multiple read() calls: it reads from
+/// the file descriptor `fd` into multiple buffers as described by `iov`. The
+/// `iocnt` argument specifies the number of elements in the `iov` array.
+///
+/// Return the total number of bytes read on success.
 pub fn sys_readv(fd: i32, iov: UserPtr<iovec>, iocnt: usize) -> LinuxResult<isize> {
     if !(0..=1024).contains(&iocnt) {
         return Err(LinuxError::EINVAL);
@@ -68,6 +157,13 @@ pub fn sys_write(fd: i32, buf: UserConstPtr<u8>, len: usize) -> LinuxResult<isiz
     Ok(get_file_like(fd)?.write(buf)? as _)
 }
 
+/// Write data to the file using a vector of buffers.
+///
+/// This function performs the same task as multiple write() calls: it writes
+/// data from multiple buffers as described by `iov` to the file descriptor `fd`.
+/// The `iocnt` argument specifies the number of elements in the `iov` array.
+///
+/// Return the total number of bytes written on success.
 pub fn sys_writev(fd: i32, iov: UserConstPtr<iovec>, iocnt: usize) -> LinuxResult<isize> {
     if !(0..=1024).contains(&iocnt) {
         return Err(LinuxError::EINVAL);
@@ -99,6 +195,13 @@ pub fn sys_writev(fd: i32, iov: UserConstPtr<iovec>, iocnt: usize) -> LinuxResul
     Ok(ret)
 }
 
+/// Reposition read/write file offset.
+///
+/// This function repositions the file offset of the open file description associated
+/// with the file descriptor `fd` to the argument `offset` according to the directive
+/// `whence`: SEEK_SET (0), SEEK_CUR (1), or SEEK_END (2).
+///
+/// Return the resulting offset location as measured in bytes from the beginning of the file.
 pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> LinuxResult<isize> {
     debug!("sys_lseek <= {} {} {}", fd, offset, whence);
     let pos = match whence {

--- a/api/src/imp/fs/io_mpx/mod.rs
+++ b/api/src/imp/fs/io_mpx/mod.rs
@@ -9,6 +9,10 @@
 //! * [`epoll_wait`](epoll::sys_epoll_wait)
 //! * [`epoll_pwait`](epoll::sys_epoll_pwait)
 
+use axerrno::LinuxResult;
+use axhal::time::wall_time;
+use core::time::Duration;
+
 mod epoll;
 mod poll;
 mod select;
@@ -16,3 +20,35 @@ mod select;
 pub use self::epoll::*;
 pub use self::poll::*;
 pub use self::select::*;
+
+/// Common polling loop that handles network polling, yielding, and timeout checking
+/// Returns Ok(Some(result)) if polling function returns a result, Ok(None) if timeout occurred
+pub(crate) fn poll_with_timeout<F, R>(
+    deadline: Option<Duration>,
+    mut poll_fn: F,
+) -> LinuxResult<Option<R>>
+where
+    F: FnMut() -> LinuxResult<Option<R>>,
+{
+    loop {
+        axnet::poll_interfaces();
+
+        if let Some(result) = poll_fn()? {
+            return Ok(Some(result));
+        }
+
+        axtask::yield_now();
+
+        if deadline.is_some_and(|ddl| wall_time() >= ddl) {
+            return Ok(None);
+        }
+    }
+}
+
+/// Handle empty nfds case with optional timeout sleep
+pub(crate) fn handle_empty_nfds(timeout: Option<Duration>) -> LinuxResult<isize> {
+    if let Some(duration) = timeout {
+        axtask::sleep(duration);
+    }
+    Ok(0)
+}

--- a/api/src/imp/fs/io_mpx/poll.rs
+++ b/api/src/imp/fs/io_mpx/poll.rs
@@ -2,11 +2,56 @@
 
 use core::{ffi::c_int, time::Duration};
 
+use super::{handle_empty_nfds, poll_with_timeout};
 use crate::file::get_file_like;
 use crate::ptr::UserPtr;
 use axerrno::LinuxResult;
 use axhal::time::wall_time;
 use linux_raw_sys::general::{POLLERR, POLLIN, POLLNVAL, POLLOUT, pollfd, sigset_t, timespec};
+
+/// Poll file descriptors and return the number of ready file descriptors
+fn poll_fds(fds: UserPtr<pollfd>, nfds: usize) -> LinuxResult<Option<isize>> {
+    let mut ready_count = 0;
+    let pollfd_slice = fds.get_as_mut_slice(nfds)?;
+
+    for pollfd_data in pollfd_slice.iter_mut().take(nfds) {
+        pollfd_data.revents = 0;
+
+        if pollfd_data.fd < 0 {
+            continue;
+        }
+
+        match get_file_like(pollfd_data.fd) {
+            Ok(file) => match file.poll() {
+                Ok(state) => {
+                    if (pollfd_data.events & POLLIN as i16) != 0 && state.readable {
+                        pollfd_data.revents |= POLLIN as i16;
+                    }
+                    if (pollfd_data.events & POLLOUT as i16) != 0 && state.writable {
+                        pollfd_data.revents |= POLLOUT as i16;
+                    }
+                    if pollfd_data.revents != 0 {
+                        ready_count += 1;
+                    }
+                }
+                Err(_) => {
+                    pollfd_data.revents = POLLERR as i16;
+                    ready_count += 1;
+                }
+            },
+            Err(_) => {
+                pollfd_data.revents = POLLNVAL as i16;
+                ready_count += 1;
+            }
+        }
+    }
+
+    if ready_count > 0 {
+        Ok(Some(ready_count))
+    } else {
+        Ok(None)
+    }
+}
 
 /// Implementation of poll system call
 pub fn sys_poll(fds: UserPtr<pollfd>, nfds: usize, timeout_ms: c_int) -> LinuxResult<isize> {
@@ -18,62 +63,16 @@ pub fn sys_poll(fds: UserPtr<pollfd>, nfds: usize, timeout_ms: c_int) -> LinuxRe
     );
 
     if nfds == 0 {
-        if timeout_ms > 0 {
-            axtask::sleep(Duration::from_millis(timeout_ms as u64));
-        }
-        return Ok(0);
+        let timeout = (!timeout_ms.is_negative()).then(|| Duration::from_millis(timeout_ms as u64));
+        return handle_empty_nfds(timeout);
     }
 
     let deadline =
         (!timeout_ms.is_negative()).then(|| wall_time() + Duration::from_millis(timeout_ms as u64));
 
-    loop {
-        axnet::poll_interfaces();
-
-        let mut ready_count = 0;
-        let pollfd_slice = fds.get_as_mut_slice(nfds)?;
-
-        for pollfd_data in pollfd_slice.iter_mut().take(nfds) {
-            pollfd_data.revents = 0;
-
-            if pollfd_data.fd < 0 {
-                continue;
-            }
-
-            match get_file_like(pollfd_data.fd) {
-                Ok(file) => match file.poll() {
-                    Ok(state) => {
-                        if (pollfd_data.events & POLLIN as i16) != 0 && state.readable {
-                            pollfd_data.revents |= POLLIN as i16;
-                        }
-                        if (pollfd_data.events & POLLOUT as i16) != 0 && state.writable {
-                            pollfd_data.revents |= POLLOUT as i16;
-                        }
-                        if pollfd_data.revents != 0 {
-                            ready_count += 1;
-                        }
-                    }
-                    Err(_) => {
-                        pollfd_data.revents = POLLERR as i16;
-                        ready_count += 1;
-                    }
-                },
-                Err(_) => {
-                    pollfd_data.revents = POLLNVAL as i16;
-                    ready_count += 1;
-                }
-            }
-        }
-
-        if ready_count > 0 {
-            return Ok(ready_count);
-        }
-
-        if deadline.is_some_and(|ddl| wall_time() >= ddl) {
-            return Ok(0);
-        }
-
-        axtask::sleep(Duration::from_millis(1));
+    match poll_with_timeout(deadline, || poll_fds(fds, nfds))? {
+        Some(ready_count) => Ok(ready_count),
+        None => Ok(0),
     }
 }
 
@@ -87,13 +86,13 @@ pub fn sys_ppoll(
     debug!("sys_ppoll <= fds: {:?}, nfds: {}", fds.address(), nfds);
 
     if nfds == 0 {
-        if !timeout.is_null() {
+        let timeout_duration = if timeout.is_null() {
+            None
+        } else {
             let ts = timeout.get_as_mut()?;
-            let duration =
-                Duration::from_secs(ts.tv_sec as u64) + Duration::from_nanos(ts.tv_nsec as u64);
-            axtask::sleep(duration);
-        }
-        return Ok(0);
+            Some(Duration::from_secs(ts.tv_sec as u64) + Duration::from_nanos(ts.tv_nsec as u64))
+        };
+        return handle_empty_nfds(timeout_duration);
     }
 
     let deadline = if timeout.is_null() {
@@ -107,52 +106,8 @@ pub fn sys_ppoll(
         )
     };
 
-    loop {
-        axnet::poll_interfaces();
-
-        let mut ready_count = 0;
-        let pollfd_slice = fds.get_as_mut_slice(nfds)?;
-
-        for pollfd_data in pollfd_slice.iter_mut().take(nfds) {
-            pollfd_data.revents = 0;
-
-            if pollfd_data.fd < 0 {
-                continue;
-            }
-
-            match get_file_like(pollfd_data.fd) {
-                Ok(file) => match file.poll() {
-                    Ok(state) => {
-                        if (pollfd_data.events & POLLIN as i16) != 0 && state.readable {
-                            pollfd_data.revents |= POLLIN as i16;
-                        }
-                        if (pollfd_data.events & POLLOUT as i16) != 0 && state.writable {
-                            pollfd_data.revents |= POLLOUT as i16;
-                        }
-                        if pollfd_data.revents != 0 {
-                            ready_count += 1;
-                        }
-                    }
-                    Err(_) => {
-                        pollfd_data.revents = POLLERR as i16;
-                        ready_count += 1;
-                    }
-                },
-                Err(_) => {
-                    pollfd_data.revents = POLLNVAL as i16;
-                    ready_count += 1;
-                }
-            }
-        }
-
-        if ready_count > 0 {
-            return Ok(ready_count);
-        }
-
-        if deadline.is_some_and(|ddl| wall_time() >= ddl) {
-            return Ok(0);
-        }
-
-        axtask::sleep(Duration::from_millis(1));
+    match poll_with_timeout(deadline, || poll_fds(fds, nfds))? {
+        Some(ready_count) => Ok(ready_count),
+        None => Ok(0),
     }
 }

--- a/api/src/imp/mm/mod.rs
+++ b/api/src/imp/mm/mod.rs
@@ -1,5 +1,7 @@
 mod brk;
 mod mmap;
+mod shm;
 
 pub use self::brk::*;
 pub use self::mmap::*;
+pub use self::shm::*;

--- a/api/src/imp/mm/shm.rs
+++ b/api/src/imp/mm/shm.rs
@@ -1,0 +1,177 @@
+//! System V shared memory system calls.
+
+use alloc::sync::Arc;
+use axerrno::{LinuxError, LinuxResult};
+use axhal::paging::{MappingFlags, PageSize};
+use axtask::{TaskExtRef, current};
+use memory_addr::VirtAddr;
+use starry_core::shm::{ShmId, ShmKey, ShmSegment, ShmidDs, shm_manager};
+
+use crate::ptr::UserPtr;
+
+const IPC_RMID: i32 = 0;
+const IPC_STAT: i32 = 2;
+const IPC_SET: i32 = 1;
+
+const SHM_RND: i32 = 0o020000;
+const SHM_RDONLY: i32 = 0o010000;
+
+const MAX_SHM_SIZE: usize = 1 << 30; // 1GB
+
+/// Validates segment consistency and permissions.
+fn validate_segment(segment: &Arc<ShmSegment>, shmflg: i32) -> LinuxResult<()> {
+    if segment
+        .marked_for_deletion
+        .load(core::sync::atomic::Ordering::SeqCst)
+    {
+        return Err(LinuxError::EIDRM);
+    }
+    if !segment.validate() {
+        return Err(LinuxError::EINVAL);
+    }
+    let access = if (shmflg & SHM_RDONLY) != 0 { 0o4 } else { 0o6 };
+    if !segment.check_permissions(0, 0, access) {
+        return Err(LinuxError::EACCES);
+    }
+    Ok(())
+}
+
+/// shmget system call - get shared memory segment.
+pub fn sys_shmget(key: ShmKey, size: usize, flags: i32) -> LinuxResult<isize> {
+    info!("sys_shmget: key={}, size={}, flags={:#x}", key, size, flags);
+    if size > MAX_SHM_SIZE || (size == 0 && key != starry_core::shm::IPC_PRIVATE) {
+        return Err(LinuxError::EINVAL);
+    }
+    let segment = shm_manager().lock().get_or_create(key, size, flags)?;
+    Ok(segment.id as isize)
+}
+
+/// shmat system call - attach shared memory segment.
+pub fn sys_shmat(shmid: ShmId, shmaddr: usize, shmflg: i32) -> LinuxResult<isize> {
+    info!(
+        "sys_shmat: shmid={}, shmaddr={:#x}, shmflg={:#x}",
+        shmid, shmaddr, shmflg
+    );
+    if shmid < 0 {
+        return Err(LinuxError::EINVAL);
+    }
+    if (shmflg & SHM_RND) == 0 && shmaddr != 0 && (shmaddr & (axhal::mem::PAGE_SIZE_4K - 1)) != 0 {
+        return Err(LinuxError::EINVAL);
+    }
+    let curr = current();
+    let process_data = curr.task_ext().process_data();
+    let mut aspace = process_data.aspace.lock();
+    let segment = {
+        let manager = shm_manager().lock();
+        let segment = manager.get_by_id(shmid)?;
+        validate_segment(&segment, shmflg)?;
+        segment.inc_attach();
+        segment
+    };
+    let size = segment.size;
+    let vaddr = if (shmflg & SHM_RND) != 0 {
+        if shmaddr == 0 {
+            return Err(LinuxError::EINVAL);
+        }
+        VirtAddr::from(shmaddr & !(axhal::mem::PAGE_SIZE_4K - 1))
+    } else if aspace.contains_range(VirtAddr::from(shmaddr), size) {
+        return Err(LinuxError::EINVAL);
+    } else {
+        aspace
+            .find_free_area(
+                VirtAddr::from(shmaddr),
+                size,
+                memory_addr::VirtAddrRange::new(aspace.base(), aspace.end()),
+                PageSize::Size4K,
+            )
+            .or_else(|| {
+                aspace.find_free_area(
+                    aspace.base(),
+                    size,
+                    memory_addr::VirtAddrRange::new(aspace.base(), aspace.end()),
+                    PageSize::Size4K,
+                )
+            })
+            .ok_or(LinuxError::ENOMEM)?
+    };
+    let mut flags = MappingFlags::USER | MappingFlags::READ;
+    if (shmflg & SHM_RDONLY) == 0 {
+        flags |= MappingFlags::WRITE;
+    }
+    let map_result = aspace.map_linear(vaddr, segment.paddr, size, flags, PageSize::Size4K);
+    if let Err(e) = map_result {
+        segment.dec_attach();
+        return Err(LinuxError::from(e));
+    }
+    let mut shm_data = process_data.shm_data.lock();
+    shm_data.attach(shmid, vaddr, segment);
+    Ok(vaddr.as_usize() as isize)
+}
+
+/// shmdt system call - detach shared memory segment.
+pub fn sys_shmdt(shmaddr: usize) -> LinuxResult<isize> {
+    info!("sys_shmdt: shmaddr={:#x}", shmaddr);
+    let curr = current();
+    let process_data = curr.task_ext().process_data();
+    let mut aspace = process_data.aspace.lock();
+    let mut shm_data = process_data.shm_data.lock();
+    let vaddr = VirtAddr::from(shmaddr);
+    let attach = shm_data.detach(vaddr).ok_or(LinuxError::EINVAL)?;
+    aspace.unmap(vaddr, attach.segment.size)?;
+    attach.segment.dec_attach();
+    let pid = curr.task_ext().thread.process().pid() as i32;
+    attach.segment.set_last_pid(pid);
+    let mut manager = shm_manager().lock();
+    if attach
+        .segment
+        .marked_for_deletion
+        .load(core::sync::atomic::Ordering::SeqCst)
+        && attach.segment.get_attach_count() == 0
+    {
+        manager.remove(attach.id)?;
+    }
+    Ok(0)
+}
+
+/// shmctl system call - control shared memory segment.
+pub fn sys_shmctl(shmid: ShmId, cmd: i32, buf: UserPtr<ShmidDs>) -> LinuxResult<isize> {
+    info!("sys_shmctl: shmid={}, cmd={}", shmid, cmd);
+    let mut manager = shm_manager().lock();
+    let segment = manager.get_by_id(shmid)?;
+    match cmd {
+        IPC_RMID => {
+            segment
+                .marked_for_deletion
+                .store(true, core::sync::atomic::Ordering::SeqCst);
+            if segment.get_attach_count() == 0 {
+                manager.remove(shmid)?;
+            }
+            Ok(0)
+        }
+        IPC_STAT => {
+            if buf.is_null() {
+                return Err(LinuxError::EFAULT);
+            }
+            let stat = segment.get_stat();
+            let user_stat = buf.get_as_mut()?;
+            *user_stat = stat;
+            Ok(0)
+        }
+        IPC_SET => {
+            if buf.is_null() {
+                return Err(LinuxError::EFAULT);
+            }
+            let user_stat = buf.get_as_mut()?;
+            segment.set_perm(
+                user_stat.shm_perm.uid,
+                user_stat.shm_perm.gid,
+                user_stat.shm_perm.mode,
+            );
+            Ok(0)
+        }
+        _ => {
+            warn!("sys_shmctl: unsupported command {}", cmd);
+            Err(LinuxError::EINVAL)
+        }
+    }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+axalloc.workspace = true
 axconfig.workspace = true
 axfs.workspace = true
 axhal.workspace = true
@@ -29,5 +30,6 @@ kernel-elf-parser = "0.3"
 numeric-enum-macro = "0.2"
 percpu = "0.2.0"
 xmas-elf = "0.9"
+lazy_static = { version = "1.5", features = ["spin_no_std"] }
 
 weak-map = "0.1.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,5 +11,6 @@ extern crate alloc;
 mod fs;
 pub mod futex;
 pub mod mm;
+pub mod shm;
 pub mod task;
 mod time;

--- a/core/src/mm.rs
+++ b/core/src/mm.rs
@@ -122,12 +122,20 @@ pub fn load_user_app(
         let pos = head.iter().position(|c| *c == b'\n').unwrap_or(head.len());
         let line = core::str::from_utf8(&head[..pos]).map_err(|_| AxError::InvalidData)?;
 
-        let new_args: Vec<String> = line
-            .splitn(2, |c: char| c.is_ascii_whitespace())
-            .map(|s| s.trim_ascii().to_owned())
-            .chain(args.iter().cloned())
-            .collect();
-        return load_user_app(uspace, &new_args[0], &new_args, envs);
+        let trimmed_line = line.trim_start();
+        if trimmed_line.is_empty() {
+        } else {
+            let new_args: Vec<String> = trimmed_line
+                .splitn(2, |c: char| c.is_ascii_whitespace())
+                .map(|s| s.trim_ascii().to_owned())
+                .filter(|s| !s.is_empty())
+                .chain(args.iter().cloned())
+                .collect();
+
+            if !new_args.is_empty() {
+                return load_user_app(uspace, &new_args[0], &new_args, envs);
+            }
+        }
     }
     let elf = ElfFile::new(&file_data).map_err(|_| AxError::InvalidData)?;
 

--- a/core/src/shm.rs
+++ b/core/src/shm.rs
@@ -1,0 +1,397 @@
+//! System V shared memory implementation for Neon-OS.
+//!
+//! This module provides System V shared memory IPC support including:
+//! - Shared memory segment management with automatic cleanup
+//! - Per-process shared memory tracking  
+//! - Secure ID allocation with collision detection
+//! - Linux-compatible permissions and error handling
+
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use axalloc::global_allocator;
+use axerrno::{AxError, AxResult};
+use axhal::mem::{PAGE_SIZE_4K, virt_to_phys};
+use axsync::Mutex;
+use axtask::{TaskExtRef, current};
+use core::sync::atomic::AtomicBool;
+use lazy_static::lazy_static;
+use memory_addr::{PhysAddr, VirtAddr, align_up_4k};
+
+/// Shared memory segment identifier.
+pub type ShmId = i32;
+
+/// Shared memory key.
+pub type ShmKey = i32;
+
+/// IPC_PRIVATE key value.
+pub const IPC_PRIVATE: ShmKey = 0;
+
+lazy_static! {
+    /// Global shared memory manager instance.
+    static ref SHM_MANAGER: Mutex<ShmManager> = Mutex::new(ShmManager::new());
+}
+
+/// Shared memory segment data structure (shmid_ds)
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ShmidDs {
+    /// IPC permissions
+    pub shm_perm: IpcPerm,
+    /// Size of segment in bytes
+    pub shm_segsz: usize,
+    /// Last attach time
+    pub shm_atime: i64,
+    /// Last detach time
+    pub shm_dtime: i64,
+    /// Last change time
+    pub shm_ctime: i64,
+    /// Creator PID
+    pub shm_cpid: i32,
+    /// Last operator PID
+    pub shm_lpid: i32,
+    /// Number of current attaches
+    pub shm_nattch: u64,
+    /// Unused fields for future expansion
+    pub shm_unused: [u32; 4],
+}
+
+/// IPC permission structure
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct IpcPerm {
+    /// Key supplied to shmget()
+    pub key: i32,
+    /// Effective UID of owner
+    pub uid: u32,
+    /// Effective GID of owner
+    pub gid: u32,
+    /// Effective UID of creator
+    pub cuid: u32,
+    /// Effective GID of creator
+    pub cgid: u32,
+    /// Permissions
+    pub mode: u32,
+    /// Sequence number
+    pub seq: u32,
+    /// Unused
+    pub _unused1: [u32; 5],
+}
+
+/// Shared memory segment.
+#[derive(Debug)]
+pub struct ShmSegment {
+    /// Shared memory segment identifier.
+    pub id: ShmId,
+    /// Physical address of the segment.
+    pub paddr: PhysAddr,
+    /// Size of the segment in bytes.
+    pub size: usize,
+    /// Standard Linux shmid_ds structure (protected by mutex).
+    pub shmid_ds: Mutex<ShmidDs>,
+    /// Whether this segment is marked for deletion.
+    pub marked_for_deletion: AtomicBool,
+}
+
+impl ShmSegment {
+    /// Creates a new shared memory segment.
+    pub fn new(id: ShmId, key: ShmKey, size: usize, mode: u16) -> AxResult<Self> {
+        let aligned_size = align_up_4k(size);
+
+        let vaddr = global_allocator()
+            .alloc_pages(aligned_size / PAGE_SIZE_4K, PAGE_SIZE_4K)
+            .map_err(|_| AxError::NoMemory)?;
+
+        let paddr = virt_to_phys(vaddr.into());
+        let current_time = axhal::time::wall_time().as_secs();
+        let creator_pid = current().task_ext().thread.process().pid() as i32;
+
+        let ipc_perm = IpcPerm {
+            key,
+            uid: 0,
+            gid: 0,
+            cuid: 0,
+            cgid: 0,
+            mode: mode as u32,
+            seq: 0,
+            _unused1: [0; 5],
+        };
+
+        let shmid_ds = ShmidDs {
+            shm_perm: ipc_perm,
+            shm_segsz: size,
+            shm_atime: 0,
+            shm_dtime: 0,
+            shm_ctime: current_time as i64,
+            shm_cpid: creator_pid,
+            shm_lpid: 0,
+            shm_nattch: 0,
+            shm_unused: [0; 4],
+        };
+
+        Ok(Self {
+            id,
+            paddr,
+            size: aligned_size,
+            shmid_ds: Mutex::new(shmid_ds),
+            marked_for_deletion: AtomicBool::new(false),
+        })
+    }
+
+    /// Increments the attachment count for this segment.
+    pub fn inc_attach(&self) {
+        let mut ds = self.shmid_ds.lock();
+        ds.shm_nattch += 1;
+        ds.shm_atime = axhal::time::wall_time().as_secs() as i64;
+    }
+
+    /// Decrements the attachment count for this segment.
+    pub fn dec_attach(&self) {
+        let mut ds = self.shmid_ds.lock();
+        if ds.shm_nattch > 0 {
+            ds.shm_nattch -= 1;
+            if ds.shm_nattch == 0 {
+                ds.shm_dtime = axhal::time::wall_time().as_secs() as i64;
+            }
+        }
+    }
+
+    /// Gets the current attachment count for this segment.
+    pub fn get_attach_count(&self) -> usize {
+        self.shmid_ds.lock().shm_nattch as usize
+    }
+
+    /// Updates the last process ID that performed an operation.
+    pub fn set_last_pid(&self, pid: i32) {
+        self.shmid_ds.lock().shm_lpid = pid;
+    }
+
+    /// Checks if the given user has the required permissions for this segment.
+    pub fn check_permissions(&self, uid: u32, gid: u32, access: u16) -> bool {
+        let ds = self.shmid_ds.lock();
+        let mode = ds.shm_perm.mode;
+
+        if uid == ds.shm_perm.uid {
+            return (mode & ((access as u32) << 6)) == ((access as u32) << 6);
+        }
+
+        if gid == ds.shm_perm.gid {
+            return (mode & ((access as u32) << 3)) == ((access as u32) << 3);
+        }
+
+        (mode & (access as u32)) == (access as u32)
+    }
+
+    /// Validates that the segment is in a consistent state.
+    pub fn validate(&self) -> bool {
+        let ds = self.shmid_ds.lock();
+
+        if ds.shm_nattch > 65536 {
+            return false;
+        }
+
+        if self.size < ds.shm_segsz || self.size < align_up_4k(ds.shm_segsz) {
+            return false;
+        }
+
+        if ds.shm_segsz == 0 || ds.shm_segsz > (1usize << 30) {
+            return false;
+        }
+
+        if self.size == 0 || self.size > (1usize << 30) {
+            return false;
+        }
+
+        if self.paddr.as_usize() == 0 {
+            return false;
+        }
+
+        true
+    }
+
+    /// Gets a copy of the shmid_ds structure for IPC_STAT.
+    pub fn get_stat(&self) -> ShmidDs {
+        *self.shmid_ds.lock()
+    }
+
+    /// Updates permissions from user space (for IPC_SET).
+    pub fn set_perm(&self, uid: u32, gid: u32, mode: u32) {
+        let mut ds = self.shmid_ds.lock();
+        ds.shm_perm.uid = uid;
+        ds.shm_perm.gid = gid;
+        ds.shm_perm.mode = mode;
+        ds.shm_ctime = axhal::time::wall_time().as_secs() as i64;
+    }
+}
+
+impl Drop for ShmSegment {
+    fn drop(&mut self) {
+        let vaddr = axhal::mem::phys_to_virt(self.paddr);
+        global_allocator().dealloc_pages(vaddr.as_usize(), self.size / PAGE_SIZE_4K);
+    }
+}
+
+/// Global shared memory manager.
+pub struct ShmManager {
+    /// Map from segment ID to segment.
+    segments: BTreeMap<ShmId, Arc<ShmSegment>>,
+    /// Map from key to segment ID.
+    key_to_id: BTreeMap<ShmKey, ShmId>,
+    /// Next segment ID to allocate.
+    next_id: ShmId,
+}
+
+impl ShmManager {
+    /// Creates a new shared memory manager.
+    pub fn new() -> Self {
+        Self {
+            segments: BTreeMap::new(),
+            key_to_id: BTreeMap::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Allocates a new segment ID with collision detection.
+    fn alloc_id(&mut self) -> AxResult<ShmId> {
+        const MAX_ATTEMPTS: usize = 1000;
+        let mut attempts = 0;
+
+        if self.segments.len() >= (i32::MAX as usize / 2) {
+            return Err(AxError::NoMemory);
+        }
+
+        loop {
+            let id = self.next_id;
+
+            self.next_id = self.next_id.wrapping_add(1);
+            if self.next_id <= 0 {
+                self.next_id = 1;
+            }
+
+            if !self.segments.contains_key(&id) {
+                return Ok(id);
+            }
+
+            attempts += 1;
+            if attempts >= MAX_ATTEMPTS {
+                return Err(AxError::NoMemory);
+            }
+        }
+    }
+
+    /// Creates or gets a shared memory segment.
+    pub fn get_or_create(
+        &mut self,
+        key: ShmKey,
+        size: usize,
+        flags: i32,
+    ) -> AxResult<Arc<ShmSegment>> {
+        let create_flag = flags & 0o01000;
+        let excl_flag = flags & 0o02000;
+        let mode = (flags & 0o777) as u16;
+
+        if key == IPC_PRIVATE {
+            let id = self.alloc_id()?;
+            let segment = Arc::new(ShmSegment::new(id, key, size, mode)?);
+            self.segments.insert(id, segment.clone());
+            return Ok(segment);
+        }
+
+        if let Some(&existing_id) = self.key_to_id.get(&key) {
+            if excl_flag != 0 {
+                return Err(AxError::AlreadyExists);
+            }
+
+            if let Some(segment) = self.segments.get(&existing_id) {
+                if segment
+                    .marked_for_deletion
+                    .load(core::sync::atomic::Ordering::SeqCst)
+                {
+                    return Err(AxError::NotFound);
+                }
+                return Ok(segment.clone());
+            } else {
+                self.key_to_id.remove(&key);
+                return Err(AxError::NotFound);
+            }
+        }
+
+        if create_flag != 0 {
+            let id = self.alloc_id()?;
+            let segment = Arc::new(ShmSegment::new(id, key, size, mode)?);
+            self.segments.insert(id, segment.clone());
+            self.key_to_id.insert(key, id);
+            Ok(segment)
+        } else {
+            Err(AxError::NotFound)
+        }
+    }
+
+    /// Gets a shared memory segment by ID.
+    pub fn get_by_id(&self, id: ShmId) -> AxResult<Arc<ShmSegment>> {
+        self.segments.get(&id).cloned().ok_or(AxError::NotFound)
+    }
+
+    /// Removes a shared memory segment.
+    pub fn remove(&mut self, id: ShmId) -> AxResult<()> {
+        if let Some(segment) = self.segments.remove(&id) {
+            let key = segment.shmid_ds.lock().shm_perm.key;
+            if key != IPC_PRIVATE {
+                self.key_to_id.remove(&key);
+            }
+            Ok(())
+        } else {
+            Err(AxError::NotFound)
+        }
+    }
+
+    /// Lists all segments (for debugging/info purposes).
+    pub fn list_segments(&self) -> impl Iterator<Item = &Arc<ShmSegment>> {
+        self.segments.values()
+    }
+}
+
+/// Shared memory attached regions per process.
+#[derive(Debug)]
+pub struct ShmAttach {
+    /// Segment ID.
+    pub id: ShmId,
+    /// Virtual address where attached.
+    pub addr: VirtAddr,
+    /// Segment reference.
+    pub segment: Arc<ShmSegment>,
+}
+
+/// Per-process shared memory tracking.
+#[derive(Debug, Default)]
+pub struct ProcessShmData {
+    /// Attached shared memory segments.
+    pub attached: BTreeMap<VirtAddr, ShmAttach>,
+}
+
+impl ProcessShmData {
+    /// Creates a new [`ProcessShmData`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attaches a shared memory segment.
+    pub fn attach(&mut self, id: ShmId, addr: VirtAddr, segment: Arc<ShmSegment>) {
+        let attach = ShmAttach { id, addr, segment };
+        self.attached.insert(addr, attach);
+    }
+
+    /// Detaches a shared memory segment.
+    pub fn detach(&mut self, addr: VirtAddr) -> Option<ShmAttach> {
+        self.attached.remove(&addr)
+    }
+
+    /// Finds attached segment by address.
+    pub fn find_by_addr(&self, addr: VirtAddr) -> Option<&ShmAttach> {
+        self.attached.get(&addr)
+    }
+}
+
+/// Gets the global shared memory manager.
+pub fn shm_manager() -> &'static Mutex<ShmManager> {
+    &SHM_MANAGER
+}

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -30,7 +30,7 @@ use memory_addr::VirtAddrRange;
 use spin::{Once, RwLock};
 use weak_map::WeakMap;
 
-use crate::{futex::FutexTable, time::TimeStat};
+use crate::{futex::FutexTable, shm::ProcessShmData, time::TimeStat};
 
 /// Create a new user task.
 pub fn new_user_task(
@@ -210,6 +210,9 @@ pub struct ProcessData {
 
     /// The futex table.
     pub futex_table: FutexTable,
+
+    /// The shared memory data.
+    pub shm_data: Mutex<ProcessShmData>,
 }
 
 impl ProcessData {
@@ -236,6 +239,7 @@ impl ProcessData {
             )),
 
             futex_table: FutexTable::new(),
+            shm_data: Mutex::new(ProcessShmData::new()),
         }
     }
 

--- a/scripts/config.toml.temp
+++ b/scripts/config.toml.temp
@@ -11,3 +11,4 @@ axns = { path = "%AX_ROOT%/modules/axns" }
 axruntime = { path = "%AX_ROOT%/modules/axruntime" }
 axsync = { path = "%AX_ROOT%/modules/axsync" }
 axtask = { path = "%AX_ROOT%/modules/axtask" }
+axalloc = { path = "%AX_ROOT%/modules/axalloc" }

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 AX_ROOT=.arceos
-COMMIT=6ae42b1
+COMMIT=25b34d1
 test ! -d "$AX_ROOT" && echo "Cloning repositories ..." || true
 test ! -d "$AX_ROOT" && git clone https://github.com/MF-B/arceos "$AX_ROOT" || true
 

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 AX_ROOT=.arceos
-COMMIT=25b34d1
+COMMIT=a6291c0
 test ! -d "$AX_ROOT" && echo "Cloning repositories ..." || true
 test ! -d "$AX_ROOT" && git clone https://github.com/MF-B/arceos "$AX_ROOT" || true
 

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -65,6 +65,21 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::write => sys_write(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::writev => sys_writev(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::lseek => sys_lseek(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::pread64 => sys_pread64(
+            tf.arg0() as _,
+            tf.arg1().into(),
+            tf.arg2() as _,
+            tf.arg3() as _,
+        ),
+        Sysno::pwrite64 => sys_pwrite64(
+            tf.arg0() as _,
+            tf.arg1().into(),
+            tf.arg2() as _,
+            tf.arg3() as _,
+        ),
+        Sysno::ftruncate => sys_ftruncate(tf.arg0() as _, tf.arg1() as _),
+        Sysno::fsync => sys_fsync(tf.arg0() as _),
+        Sysno::sync => sys_sync(),
 
         // fs mount
         Sysno::mount => sys_mount(

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -145,6 +145,12 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::munmap => sys_munmap(tf.arg0(), tf.arg1() as _),
         Sysno::mprotect => sys_mprotect(tf.arg0(), tf.arg1() as _, tf.arg2() as _),
 
+        // shared memory
+        Sysno::shmget => sys_shmget(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::shmat => sys_shmat(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::shmdt => sys_shmdt(tf.arg0() as _),
+        Sysno::shmctl => sys_shmctl(tf.arg0() as _, tf.arg1() as _, tf.arg2().into()),
+
         // task info
         Sysno::getpid => sys_getpid(),
         Sysno::getppid => sys_getppid(),


### PR DESCRIPTION
## 概述
为 Free-OS 实现iozone测例

### 主要变更
- **新增系统调用**: 实现 `shmget`, `shmat`, `shmdt`, `shmctl`
- **修复io_mpx轮询逻辑**: 在每次轮询返回前使用yield_now(),防止出现饿死进程
- **改进io_mpx处理**: 提取io_mpx的重复逻辑为公共函数
- **依赖更新**: 更新arceos

### 技术实现
- 在 `core/src/shm.rs` 中实现共享内存管理器
- 在 `api/src/imp/mm/shm.rs` 中实现系统调用逻辑
- 在 ProcessData中添加共享内存数据段

### 测试
- 修改apps/oscomp/testcase_list的内容为: 
```bash
/musl/busybox ln -s /musl/lib/libc.so /lib/ld-musl-riscv64.so.1
/musl/busybox sh /musl/iozone_testcode.sh
```
- 执行`make oscomp_run ARCH=riscv64`(或其他架构,需要相应更改testcase_list)

### 已知问题
- 测试在多核情况下不通过
